### PR TITLE
Feature: CSP module

### DIFF
--- a/index.php
+++ b/index.php
@@ -148,6 +148,13 @@ function toolbelt_get_modules() {
 			'supports' => array( 'gdpr-hard-mode', 'css-properties' ),
 			'weight' => esc_html__( '1.2kb of inline JS and CSS.', 'wp-toolbelt' ),
 		),
+		'content-security-policy' => array(
+			'name'        => esc_html__( 'Content Security Policy Headers', 'wp-toolbelt' ),
+			'description' => esc_html__( 'Inject a content security policy header into your page responses', 'wp-toolbelt' ),
+			'docs'        => 'https://github.com/BinaryMoon/wp-toolbelt/wiki/CSP-Header',
+			'supports'    => array( 'experimental' ),
+			'weight'      => esc_html__( 'Roughly 1kb of header properties', 'wp-toolbelt' )
+		),
 		'disable-comment-urls' => array(
 			'name' => esc_html__( 'Disable the Comment URL Field', 'wp-toolbelt' ),
 			'description' => esc_html__( 'Remove the URL field from comment forms. This may only work on the core comment form, and not on custom ones added to themes.', 'wp-toolbelt' ),

--- a/modules/content-security-policy/module.php
+++ b/modules/content-security-policy/module.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Content Security Policy.
+ *
+ * @package toolbelt
+ */
+
+// Don't display in the WordPress admin.
+if ( is_admin() ) {
+	return;
+}
+
+function toolbelt_csp_headers() {
+	$_csp_cache = wp_cache_get( 'csp-cache', 'toolbelt' );
+
+	$default_options = array(
+		'default-src'               => array(
+			'*',
+		),
+		'upgrade-insecure-requests' => true,
+		'block-all-mixed-content'   => true,
+		'report-only'               => true,
+		'report-uri'                => '',
+		'report-to'                 => '', // New for CSP level 3 https://www.w3.org/TR/CSP/#changes-from-level-2
+	);
+
+	$admin_policy = apply_filters( 'toolbelt_csp_policy', $default_options );
+
+	if ( false == $_csp_cache ) {
+		if ( true == $admin_policy['report-only'] ) {
+			$csp_string = "Content-Security-Policy-Report-Only";
+		} else {
+			$csp_string = "Content-Security-Policy";
+		}
+
+		foreach ( $admin_policy as $rule => $setting ) {
+			if ( is_array( $setting ) ) {
+				$csp_string .= $rule;
+				foreach ( $setting as $option ) {
+					$csp_string .= " {$item}";
+				}
+			} else {
+				$csp_string .= "{$rule} {$setting}";
+			}
+			$csp_string .= "; "; // separator
+		}
+
+		$csp_string = trim( $csp_string );
+
+		wp_cache_set(
+			'csp-cache',
+			$csp_string,
+			'toolbelt',
+			3600 // One hour
+		);
+
+		header( $csp_string );
+	} else {
+		header( $_csp_cache );
+	}
+}
+
+add_filter( 'send_headers', 'toolbelt_csp_headers' );

--- a/modules/content-security-policy/module.php
+++ b/modules/content-security-policy/module.php
@@ -26,8 +26,9 @@ function toolbelt_csp_headers() {
 
 	$admin_policy = apply_filters( 'toolbelt_csp_policy', $default_options );
 
-	if ( false == $_csp_cache ) {
+	if ( false == $_csp_cache ) { // Only rebuild if cache is empty
 		if ( true == $admin_policy['report-only'] ) {
+			// Testing for report only mode, or 'production mode'
 			$csp_string = "Content-Security-Policy-Report-Only";
 		} else {
 			$csp_string = "Content-Security-Policy";
@@ -35,11 +36,19 @@ function toolbelt_csp_headers() {
 
 		foreach ( $admin_policy as $rule => $setting ) {
 			if ( is_array( $setting ) ) {
+				// If we have a more complex rule, or one with multiple
+				// properties, build it a piece at a time
+
 				$csp_string .= $rule;
 				foreach ( $setting as $option ) {
-					$csp_string .= " {$item}";
+					// Add the property to the rule
+					$csp_string .= " {$option}";
 				}
+			} else if ( true == $setting ) {
+				// Boolean values don't have any properties
+				$csp_string .= "${rule}";
 			} else {
+				// Simpler k=>v properties
 				$csp_string .= "{$rule} {$setting}";
 			}
 			$csp_string .= "; "; // separator

--- a/modules/content-security-policy/module.php
+++ b/modules/content-security-policy/module.php
@@ -28,9 +28,10 @@ function toolbelt_csp_headers() {
 
 	if ( false == $_csp_cache ) { // Only rebuild if cache is empty
 		if ( true == $admin_policy['report-only'] ) {
-			// Testing mode is report only mode, or 'production mode'
+			// Testing mode
 			$csp_string = "Content-Security-Policy-Report-Only";
 		} else {
+			// Enforce mode
 			$csp_string = "Content-Security-Policy";
 		}
 

--- a/modules/content-security-policy/module.php
+++ b/modules/content-security-policy/module.php
@@ -28,7 +28,7 @@ function toolbelt_csp_headers() {
 
 	if ( false == $_csp_cache ) { // Only rebuild if cache is empty
 		if ( true == $admin_policy['report-only'] ) {
-			// Testing for report only mode, or 'production mode'
+			// Testing mode is report only mode, or 'production mode'
 			$csp_string = "Content-Security-Policy-Report-Only";
 		} else {
 			$csp_string = "Content-Security-Policy";
@@ -56,6 +56,7 @@ function toolbelt_csp_headers() {
 
 		$csp_string = trim( $csp_string );
 
+		// Stuff it into the cache
 		wp_cache_set(
 			'csp-cache',
 			$csp_string,
@@ -63,8 +64,10 @@ function toolbelt_csp_headers() {
 			3600 // One hour
 		);
 
+		// Send the header
 		header( $csp_string );
 	} else {
+		// Send the cached header
 		header( $_csp_cache );
 	}
 }


### PR DESCRIPTION
Here is a new module that I actually factored out of my own core module that I use on my own site.

This module adds a CSP header to page requests. By default, this is very permissive in order to prevent site breakage. Utilizing the filter, though, an admin can apply a site-wide CSP easily without having to muck with web server configurations or the various lackluster plugins on WPORG.

Ideally, I'd like to make this more flexible and allow specific rules to be applied to different pages/types like the social sharing module does. Additionally, I flagged this in the admin screen as experimental as without proper configuration, it could break your site (or, at least, appear to).

More information about CSPs and their benefits can be found on [Mozilla's site][1], and [a generator is available on Report URI][2].

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
[2]: https://report-uri.com/home/generate