### PR TITLE
Fix PHP warnings for social sharing settings

### DIFF
--- a/modules/social-sharing/module.php
+++ b/modules/social-sharing/module.php
@@ -331,6 +331,10 @@ function toolbelt_social_networks() {
 	// Get the plugin settings.
 	$settings = get_option( 'toolbelt_settings', array() );
 
+	if ( ! isset( $settings['social-sharing'] ) ) {
+		$settings['social-sharing'] = '';
+	}
+
 	// Turn the list of networks into an array.
 	$enabled_networks = explode( '|', $settings['social-sharing'] );
 

--- a/modules/social-sharing/settings.php
+++ b/modules/social-sharing/settings.php
@@ -14,6 +14,10 @@ function toolbelt_social_sharing_fields() {
 
 	$settings = get_option( 'toolbelt_settings', array() );
 
+	if ( ! isset( $settings['social-sharing'] ) ) {
+		$settings['social-sharing'] = '';
+	}
+
 	$enabled_networks = explode( '|', $settings['social-sharing'] );
 
 	$networks = toolbelt_social_networks_get();


### PR DESCRIPTION
Setting an empty string if `$settings['social-sharing']` does not exist.
